### PR TITLE
Fix redirect logic for logging in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,6 @@ class ApplicationController < ActionController::Base
 
   def require_no_user
     if current_user
-      store_location
       flash[:notice] = "You must be logged out to access this page"
       redirect_back_or_default account_url
       return false


### PR DESCRIPTION
Since UserSessions#new and UserSessions#create had the :require_no_user before_filter the store_location was getting overwritten when users were redirected to the login page.
