### PR TITLE
Auto-incrementing "assigned team number" feature

### DIFF
--- a/app/assets/javascripts/flash_fade.js.coffee
+++ b/app/assets/javascripts/flash_fade.js.coffee
@@ -1,4 +1,4 @@
 # this fades the rails flash in and out.
 
-$(document).ready ->
-  $(".alert").delay(2500).fadeTo(1000, 0)
+#$(document).ready ->
+  #$(".alert").delay(2500).fadeTo(1000, 0)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,7 +36,7 @@ class UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     if @user.update_attributes user_params
-      flash[:notice] = I18n.t('users.update.update_success')
+      flash[:info] = I18n.t('users.update.update_success')
       redirect_to user_url(@user)
     else
       flash.now[:error] = [t('update_failed')]

--- a/app/helpers/money_helper.rb
+++ b/app/helpers/money_helper.rb
@@ -1,5 +1,6 @@
 module MoneyHelper
   def price_in_dollars_and_cents(cents)
-    cents.to_s.insert(-3, '.')
+    return '0.00' unless cents
+    cents == 0 ? '0.00' : cents.to_s.insert(-3, '.')
   end
 end

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -10,10 +10,11 @@ class Race < ActiveRecord::Base
 
   # todo: validate filter_field based on contents of jsonform schema
 
-  scope :past, -> { where("race_datetime < ?", Time.now) }
+  scope :past,    -> { where("race_datetime < ?", Time.now) }
   scope :current, -> { where("race_datetime > ?", Time.now) }
 
   has_many :teams
+  MAX_TEAMS_PER_RACE = 4096 # arbitrary number of maximum teams per race.
 
   # Each race has different registration requirements that needs
   # to be fulfilled before a team is fully registered.
@@ -86,9 +87,7 @@ class Race < ActiveRecord::Base
 
     def load_stats(race_id)
       race = Race.find race_id
-
-      money_raised = race.finalized_teams.reduce(0) { |memo, t| memo + t.money_paid_in_cents }
-
+      money_raised = race.teams.reduce(0) { |memo, t| memo + t.money_paid_in_cents }
       {
         'money_raised' => money_raised
       }

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -37,7 +37,7 @@
               %li= link_to t('new'), new_user_path
               %li.divider
 
-      %li
+      -#%li
         %a{:"href" => '#shopify-store'}
           %i.fa.fa-diamond.fa-2x
           =t 'shop'

--- a/app/views/homepages/index.html.haml
+++ b/app/views/homepages/index.html.haml
@@ -30,7 +30,7 @@
     %p
       Now, please click MUSH ON to begin.
 
-    %p
+    -#%p
       %a{:"href" => '#shopify-store'}
         %i.fa.fa-diamond.fa-3x.pull-left
         %h2

--- a/app/views/teams/_table.html.haml
+++ b/app/views/teams/_table.html.haml
@@ -7,6 +7,8 @@
       %th.filter-false Team Experience
       %th.filter-false Racer Experience
       %th Team
+      - if current_user.is_any_of?(:admin, :operator)
+        %th Number
       - if filter_field.any?
         - filter_field.each do |f|
           %th.filter-select
@@ -50,6 +52,11 @@
         %p
           %i.fa.fa-quote-left.pull-left.fa-border
           = team.description
+
+      %td
+        - if current_user.is_any_of?(:admin, :operator)
+          %h4
+            = team.assigned_team_number
 
       - if filter_field.any?
         - filter_field.each do |f|

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -39,6 +39,11 @@
           = t('.registering_for')
         = link_to @race.name, race_path(@race)
 
+        - if @team.assigned_team_number && current_user.is_any_of?(:admin, :operator)
+          as team
+          \#
+          = @team.assigned_team_number
+
       - if @team.race.open_for_registration?
         = t('.can_change_until', :date => @race.registration_close.strftime('%B %e, %Y'))
       - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,7 +104,7 @@ en:
       instructions: Once you create an account, you can create a team and register for a race.
     update:
       update_user: Update your account
-      update_success: Thanks for updating your account information.
+      update_success: Account information successfully updated.
     edit:
       update_user: Update your account
 

--- a/db/migrate/20160115052426_add_assigned_team_number_to_team.rb
+++ b/db/migrate/20160115052426_add_assigned_team_number_to_team.rb
@@ -1,0 +1,9 @@
+class AddAssignedTeamNumberToTeam < ActiveRecord::Migration
+  def up
+    add_column :teams, :assigned_team_number, :integer
+  end
+
+  def down
+    remove_column :teams, :assigned_team_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160115050348) do
+ActiveRecord::Schema.define(version: 20160115052426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,7 +26,6 @@ ActiveRecord::Schema.define(version: 20160115050348) do
   end
 
   add_index "completed_requirements", ["team_id", "requirement_id"], name: "index_completed_requirements_on_team_id_and_requirement_id", unique: true, using: :btree
-  add_index "completed_requirements", ["user_id"], name: "index_completed_requirements_on_user_id", using: :btree
 
   create_table "people", force: true do |t|
     t.string   "first_name"
@@ -40,8 +39,6 @@ ActiveRecord::Schema.define(version: 20160115050348) do
     t.integer  "experience"
     t.string   "zipcode",    null: false
   end
-
-  add_index "people", ["team_id"], name: "index_people_on_team_id", using: :btree
 
   create_table "races", force: true do |t|
     t.string   "name"
@@ -79,10 +76,10 @@ ActiveRecord::Schema.define(version: 20160115050348) do
     t.text     "private_comments"
     t.text     "jsonform"
     t.boolean  "finalized"
+    t.integer  "assigned_team_number"
   end
 
   add_index "teams", ["race_id"], name: "index_teams_on_race_id", using: :btree
-  add_index "teams", ["user_id"], name: "index_teams_on_user_id", using: :btree
 
   create_table "tiers", force: true do |t|
     t.integer  "requirement_id"

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -180,7 +180,7 @@ describe UsersController do
           patch :update, :id => some_user.id, :user => {:phone => '000-000-0000'}
           expect(some_user.reload.phone).to eq('000-000-0000')
           expect(controller.should_run_update_checker).to be_false
-          expect(flash[:notice]).to eq(I18n.t 'users.update.update_success')
+          expect(flash[:info]).to eq(I18n.t 'users.update.update_success')
           expect(response).to redirect_to(some_user)
         end
       end

--- a/spec/factories/team.rb
+++ b/spec/factories/team.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
 
   factory :team do
     sequence(:name)    { |n| "Team #{n}" }
-    description        { |n| "omg! #{name} is the best team evar." }
+    description        { "omg! #{name} is the best team evar." }
     sequence(:twitter) { |n| "@twitter#{n}" }
     experience 5
 
@@ -10,9 +10,11 @@ FactoryGirl.define do
     race
 
     factory :finalized_team do
-      finalized true
       after(:create) do |team|
-        create_list(:person, 5, team: team)
+        Timecop.freeze(THE_TIME) do
+          create_list(:person, 5, team: team)
+          team.finalize
+        end
       end
     end
   end

--- a/spec/factories/tier.rb
+++ b/spec/factories/tier.rb
@@ -1,10 +1,7 @@
-# TODO: consolidate 'thetime' variable to a single place.
-thetime = Time.local(1980, 9, 1, 12, 0, 0)
-
 FactoryGirl.define do
   factory :tier do
     ignore do
-      thetime { Timecop.freeze(thetime) { Time.now } }
+      thetime { Timecop.freeze(THE_TIME) { Time.now } }
     end
 
     price 5000

--- a/spec/helpers/money_helper.rb
+++ b/spec/helpers/money_helper.rb
@@ -6,6 +6,13 @@ describe MoneyHelper do
     it 'returns an integer of cents as a string of dollars and cents' do
       expect(price_in_dollars_and_cents(10000)).to eq('100.00')
     end
-  end
 
+    it 'returns 0.00 when cents is nil' do
+      expect(price_in_dollars_and_cents(nil)).to eq('0.00')
+    end
+
+    it 'returns 0.00 when cents is 0' do
+      expect(price_in_dollars_and_cents(0)).to eq('0.00')
+    end
+  end
 end

--- a/spec/models/payment_requirement_spec.rb
+++ b/spec/models/payment_requirement_spec.rb
@@ -15,8 +15,7 @@ describe PaymentRequirement do
     it 'sets the company name to the race name'
   end
 
-  let(:thetime) { Time.local(1980, 9, 1, 12, 0, 0) }
-  before { Timecop.freeze(thetime) }
+  before { Timecop.freeze(THE_TIME) }
   after  { Timecop.return }
 
   describe '#enabled?' do

--- a/spec/models/tier_spec.rb
+++ b/spec/models/tier_spec.rb
@@ -2,12 +2,11 @@ require 'spec_helper'
 
 describe Tier do
 
-  let(:thetime) { Time.local(1980, 9, 1, 12, 0, 0) }
-  before { Timecop.freeze(thetime) }
+  before { Timecop.freeze(THE_TIME) }
   after  { Timecop.return }
 
   let!(:req) do
-    Timecop.freeze(thetime) do
+    Timecop.freeze(THE_TIME) do
       FactoryGirl.create :payment_requirement_with_tier
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,9 @@ include Authlogic::TestCase
 # CanCan authorization
 require "cancan/matchers"
 
+# Global time constant for use with Timecop
+THE_TIME = Time.local(1980, 9, 1, 12, 0, 0)
+
 def mock_login!(user)
   expect(user).to_not be_nil
   session = UserSession.create!(user, false)


### PR DESCRIPTION
- Every time a team is finalized, the field 'assigned_team_number' gets set onto the Team and is never removed.
- A team never loses its assigned team number, even if they are not finalized and able to race. Immutable
- Re-use the same assigned team number if already present
- Added assigned team name to CSV export
- Comment out flash fadeout
- Strengthened the money helper
- Commented out the store and the code that fades the flash
- General spec cleanup