### PR TITLE
Specs for Stripe Refund, Stripe Helper improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ group :test do
   gem 'timecop'
   gem 'webmock'
   gem 'simplecov'
-  gem 'stripe-ruby-mock', '~> 2.2.1'
+  gem 'stripe-ruby-mock', '~> 2.3.1'
   gem 'codeclimate-test-reporter'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,6 @@ GEM
     autoprefixer-rails (6.5.3.1)
       execjs
     awesome_print (1.7.0)
-    blankslate (3.1.3)
     bootstrap-sass (3.3.5)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
@@ -117,11 +116,6 @@ GEM
     jbuilder (1.5.3)
       activesupport (>= 3.0.0)
       multi_json (>= 1.2.0)
-    jimson-temp (0.9.5)
-      blankslate (>= 3.1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.4)
-      rest-client (~> 1.0)
     jquery-rails (4.2.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -270,10 +264,10 @@ GEM
     stripe (1.31.0)
       json (~> 1.8.1)
       rest-client (~> 1.4)
-    stripe-ruby-mock (2.2.4)
+    stripe-ruby-mock (2.3.1)
       dante (>= 0.2.0)
-      jimson-temp
-      stripe (>= 1.31.0, < 1.42)
+      multi_json (~> 1.0)
+      stripe (~> 1.31)
     test-unit (3.2.3)
       power_assert
     thin (1.5.1)
@@ -336,7 +330,7 @@ DEPENDENCIES
   sdoc
   simplecov
   stripe (~> 1.31.0)
-  stripe-ruby-mock (~> 2.2.1)
+  stripe-ruby-mock (~> 2.3.1)
   test-unit
   timecop
   uglifier (>= 1.3.0)

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -1,6 +1,7 @@
 class ChargesController < ApplicationController
   before_filter :require_user
   before_filter :require_stripe_params, only: [:create]
+  before_filter :require_prior_url
 
   STRIPE_PARAMS = ['amount', 'stripeToken', 'stripeEmail', 'description', 'metadata']
 
@@ -18,19 +19,17 @@ class ChargesController < ApplicationController
 
     metadata = JSON.parse params[:metadata]
 
-    begin
-      charge = Stripe::Charge.create(
-        :customer    => @customer.id,
-        :amount      => params[:amount],
-        :description => params[:description],
-        :metadata    => metadata,
-        :currency    => 'usd'
-      )
-    end
+    charge = Stripe::Charge.create(
+      :customer    => @customer.id,
+      :amount      => params[:amount],
+      :description => params[:description],
+      :metadata    => metadata,
+      :currency    => 'usd'
+    )
 
     # if we're here, we have a successful charge.
     # create a completed_requirement object and save it.
-
+    # TODO: move away from instance variable
     @cr_metadata = {
       'customer_id' => @customer.id,
       'charge_id' => charge.id,
@@ -44,16 +43,17 @@ class ChargesController < ApplicationController
     url = session.delete(:prior_url)
     redirect_to url
 
+  # TODO: figure out how to consolidate this logic with the logic from stripe_helper
   rescue Stripe::CardError => e
     flash[:error] = e.message
     log_and_redirect(e)
   rescue Stripe::InvalidRequestError => e
     error = StripeHelper.exception_to_hash(e)
-    flash[:error] = "Invalid parameters supplied to Stripe API. Please email dogtag@chiditarod.org with this info: #{error[:message]}"
+    flash[:error] = "Invalid parameters supplied to Stripe API. Please email dogtag@chiditarod.org with this info: #{error[:reason]}"
     log_and_redirect(e)
   rescue Stripe::APIConnectionError => e
     error = StripeHelper.exception_to_hash(e)
-    flash[:error] = "There is an issue connecting to the Stripe API: #{error[:message]}"
+    flash[:error] = "There is an issue connecting to the Stripe API: #{error[:reason]}"
     log_and_redirect(e)
   rescue Stripe::StripeError => e
     flash[:error] = 'An error occured connecting to Stripe. Please email dogtag@chiditarod.org.'
@@ -68,36 +68,42 @@ class ChargesController < ApplicationController
 
     Rails.logger.info "Refund requested for charge: #{params[:charge_id]}"
 
-    StripeHelper.safely_call_stripe do
+    success, ex = StripeHelper.safely_call_stripe do
       @charge = Stripe::Charge.retrieve(params[:charge_id])
     end
 
-    return render :status => 404, :error => 'Charge not found' unless @charge
-    return render :status => 400, :error => 'Already Refunded' if @charge.refunded
+    return render status: 404, json: {error: ex.message} unless success
+    return render status: 400, json: {error: "Charge ID #{@charge.id} is already refunded"} if @charge.refunded
 
     StripeHelper.safely_call_stripe do
       @charge = @charge.refund
     end
 
+    # TODO: re-evaluate if we want to render 500 here.
     unless @charge.refunded
       str = "Charge ID: #{@charge.id} could not be refunded. No action taken."
-      Rails.logger.info str
-      return render status: 500, error: str
+      Rails.logger.error(str)
+      return render status: 500, json: {error: str}
     end
 
     req_id = @charge['metadata']['requirement_id']
-    # this supports both the old registration_id and the newer team_id
+    # we used to have a registration table that linked a team (to be used more than once) to a race. we later
+    # removed the registration table in favor of a single-use team object that registers for a single race.
+    # We used to store the registration_id in stripe, and later changed to a team_id but kept support for
+    # loading registration_id for older datasets.
     team_id = @charge['metadata']['team_id'] || @charge['metadata']['registration_id']
 
+    # TODO: Do we want to delete the completed requirement, or change its status to
+    # indicate it is no longer completed, but keep the object there to show the history?
+    # Introduce papertrail on completed requirement to track when the requirement is deleted
+    # and by whom.  YES!
     cr = CompletedRequirement.where(:requirement_id => req_id, :team_id => team_id).first
     CompletedRequirement.delete(cr)
 
-    redirect_to team_url(team_id)
-
-  rescue Stripe::InvalidRequestError => e
-    flash[:error] = e.message
-    redirect_to session[:prior_url]
-    session.delete :prior_url
+    # finally, redirect
+    flash[:notice] = "The refund has processed successfully."
+    url = session.delete(:prior_url)
+    redirect_to url
   end
 
   private
@@ -108,6 +114,19 @@ class ChargesController < ApplicationController
     redirect_to url
   end
 
+  # require that session[:prior_url] exists. this allows this controller's methods
+  # to know where to redirect the agent once the method completes.
+  def require_prior_url
+    unless session[:prior_url]
+      render(
+        status: 400,
+        json: {
+          errors: "The calling controller should set session[:prior_url] so this method knows where to return to. e.g. session[:prior_url] = request.original_url"
+        }
+      )
+    end
+  end
+
   def require_stripe_params
     stripe_params = params.slice(*STRIPE_PARAMS)
     if stripe_params.size < STRIPE_PARAMS.size
@@ -115,7 +134,7 @@ class ChargesController < ApplicationController
       render(
         status: :bad_request,
         json: {
-          errors: "Missing required stripe parameter(s): #{missing.join(',')}",
+          errors: "Missing required stripe parameter(s): #{missing.join(',')}"
         }
       )
     end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -54,6 +54,9 @@ class TeamsController < ApplicationController
     process_if_newly_finalized
 
     @race = @team.race
+
+    # currently required by charges controller to know where to redirect
+    # the user after performing an action
     session[:prior_url] = request.original_url
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -36,7 +36,7 @@ class Ability
     can [:show, :create], :questions
 
     # Stripe charges
-    can [:create, :refund], :charges
+    can [:create], :charges
 
     #todo implement at some point
     #can [:destroy], Team do |team|
@@ -62,13 +62,14 @@ class Ability
 
     if user.is? :refunder
       can [:index], User
+      can [:refund], :charges
     end
 
     if user.is? :operator
       can [:export], Race
-      can [:read, :update], Team
-      can [:read, :update], Person
+      can [:read, :update], [Team, Person]
       can [:read, :create, :update], [Race, PaymentRequirement, Tier]
+      can [:refund], :charges
     end
   end
 end

--- a/app/models/payment_requirement.rb
+++ b/app/models/payment_requirement.rb
@@ -18,17 +18,6 @@ class PaymentRequirement < Requirement
     }
   end
 
-  def charge_data(reg)
-    metadata = metadata_for(reg)
-    return false if metadata.blank?
-    return metadata['charge'] if metadata['charge'].present?
-    false
-
-    # todo: after specing replace with this
-    #return false unless (metadata.present? && metadata['charge'].present?)
-    #return metadata['charge']
-  end
-
   def enabled?
     active_tier.present?
   end

--- a/spec/factories/requirement.rb
+++ b/spec/factories/requirement.rb
@@ -17,7 +17,7 @@ FactoryGirl.define do
     factory :payment_requirement_with_tier, :aliases => [:enabled_payment_requirement] do
       name 'Payment Requirement w/ tier'
       after(:create) do |pay_req, evaluator|
-        create_list(:tier, 1, requirement: pay_req)
+        create_list(:tier, 1, requirement_id: pay_req.id)
       end
     end
   end


### PR DESCRIPTION
- Fully spec charges controller
- DRY up stripe_helper
- stripe_helper now returns [boolean, exception], where boolean is true if success, and false if failure, along with the exception
- Removed some dead, unused code
- Added more specs in other missing places
- Fixed a refund security hole.
