### PR TITLE
Scale down sidekiq workers, Add some translations

### DIFF
--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -56,15 +56,16 @@
                 = link_to edit_user_path(current_user) do
                   %i.fa.fa-edit.fa-fw
                   Edit Profile
+                  =t '.edit_profile'
               %li
                 = link_to user_session_path, :method => :delete, :data => {:confirm => 'Are you sure?'} do
                   %i.fa.fa-sign-out.fa-fw
-                  Logout
+                  =t '.logout'
       - else
         %li.dropdown
           %a.dropdown-toggle{"data-toggle" => "dropdown", href: "#"}
             %i.fa.fa-sign-in.fa-2x
-            Login
+            =t '.login'
             %b.caret
             %ul.dropdown-menu
               %li
@@ -87,14 +88,14 @@
           %b.caret
           %ul.dropdown-menu
             %li.dropdown-header
-              Having Problems?
+              =t '.having_problems'
             %li
               = link_to "mailto:dogtag@chiditarod.org?subject=dogtag help" do
                 %i.fa.fa-envelope-o.fa-fw
-                Email us
+                =t '.email_us'
             %li
               = link_to "https://github.com/chiditarod/dogtag/issues/new" do
                 %i.fa.fa-fw.fa-github
-                File a Bug
+                =t '.report_a_bug'
 
 = render 'store'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,14 @@ en:
       races: Races
       users: Users
       my_teams: My Teams
+      register: Register
+      login: Login
+      forgot_password: Forgot Password?
+      edit_profile: Edit Profile
+      logout: Logout
+      email_us: Email us
+      report_a_bug: Report a Bug
+      having_problems: Having Problems?
 
   please_create_to_continue: Please create one to continue.
   must_select_race: You must select a race to register for.

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,7 @@
 staging:
   :concurrency: 5
 production:
-  :concurrency: 25
+  :concurrency: 10
 :queues:
 - [important, 2]
 - default


### PR DESCRIPTION
Our sidekiq needs are not heavy, allowing us to tone down the concurrent workers and use a smaller Heroku redis profile.

Also adds some translations in the navbar that I noticed were missing.