### PR TITLE
Allow refunder role refund payments without destroying the completed requirement

### DIFF
--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -27,8 +27,8 @@ class RacesController < ApplicationController
 
   def registrations
     @race = Race.find params[:race_id]
-    @finalized_teams = Team.all_finalized.where(race_id: @race.id).order('updated_at DESC')
-    @waitlisted_teams = Team.all_unfinalized.where(race_id: @race.id).order('updated_at DESC')
+    @finalized_teams = Team.all_finalized.where(race_id: @race.id).order('updated_at DESC').includes(:people)
+    @waitlisted_teams = Team.all_unfinalized.where(race_id: @race.id).order('updated_at DESC').includes(:people)
   end
 
   def export

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,7 +2,7 @@ class Ability
   include CanCan::Ability
 
   # See the wiki for details:
-  # https://github.com/ryanb/cancan/wiki/Defining-Abilities
+  # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
   def initialize(user)
 
     alias_action :new, :to => :create
@@ -11,10 +11,6 @@ class Ability
     alias_action :create, :read, :update, :destroy, :to => :crud
 
     user ||= User.new
-
-    if user.is? :admin
-      can :manage, :all
-    end
 
     # guest-only stuff
     unless user.id
@@ -62,6 +58,7 @@ class Ability
 
     if user.is? :refunder
       can [:index], User
+      can [:read], Team
       can [:refund], :charges
     end
 
@@ -70,6 +67,10 @@ class Ability
       can [:read, :update], [Team, Person]
       can [:read, :create, :update], [Race, PaymentRequirement, Tier]
       can [:refund], :charges
+    end
+
+    if user.is? :admin
+      can :manage, :all
     end
   end
 end

--- a/app/models/completed_requirement.rb
+++ b/app/models/completed_requirement.rb
@@ -17,4 +17,21 @@ class CompletedRequirement < ActiveRecord::Base
     return m if m.is_a?(Hash)
     return JSON.load(m)
   end
+
+  # lookup a completed requirement by a stripe charge and delete it.
+  def self.delete_by_charge(charge)
+
+    req_id = charge['metadata']['requirement_id']
+
+    # we used to have a registration table that linked a team (to be used more than once) to a race. we later
+    # removed the registration table in favor of a single-use team object that registers for a single race.
+    # We used to store the registration_id in stripe, and later changed to a team_id but kept support for
+    # loading registration_id for older datasets.
+    team_id = charge['metadata']['team_id'] || charge['metadata']['registration_id']
+
+    # Introduce papertrail on completed requirement to track when the requirement is deleted
+    # and by whom.  YES!
+    cr = CompletedRequirement.where(requirement_id: req_id, team_id: team_id).first
+    CompletedRequirement.destroy(cr)
+  end
 end

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -55,7 +55,6 @@
               %li
                 = link_to edit_user_path(current_user) do
                   %i.fa.fa-edit.fa-fw
-                  Edit Profile
                   =t '.edit_profile'
               %li
                 = link_to user_session_path, :method => :delete, :data => {:confirm => 'Are you sure?'} do

--- a/app/views/requirements/_payment_requirement.html.haml
+++ b/app/views/requirements/_payment_requirement.html.haml
@@ -12,8 +12,10 @@
       = price_in_dollars_and_cents cr.metadata['amount']
     = t('completed')
 
-    - if current_user.is_any_of? :admin, :refunder
+    - if current_user.is_any_of? [:refunder, :admin]
       = button_to t('refund'), charge_refund_url(charge.id), :method=>:post, :data => { :confirm => 'Are you sure?'}, :class=> %w(btn btn-danger)
+    - if current_user.is? :admin
+      = button_to t('refund_and_invalidate'), charge_refund_url(charge.id), :method=>:post, :data => { :confirm => 'Are you sure?'}, :class=> %w(btn btn-danger), :params => {:delete_completed_requirement => true}
 
 - else
 

--- a/app/views/teams/_table.html.haml
+++ b/app/views/teams/_table.html.haml
@@ -2,12 +2,12 @@
   %thead
     %tr
       %th.filter-false Status
-      - if current_user.is_any_of?(:admin, :operator)
+      - if current_user.is_any_of?(:admin, :operator, :refunder)
         %th.filter-false Payments
       %th.filter-false Team Experience
       %th.filter-false Racer Experience
       %th Team
-      - if current_user.is_any_of?(:admin, :operator)
+      - if current_user.is_any_of?(:admin, :operator, :refunder)
         %th Number
       - if filter_field.any?
         - filter_field.each do |f|
@@ -26,7 +26,7 @@
               = team.percent_complete
               &#37;
 
-      - if current_user.is_any_of?(:admin, :operator)
+      - if current_user.is_any_of?(:admin, :operator, :refunder)
         %td{:style => 'width: 100px'}
           %p
             = team.requirements.count
@@ -44,7 +44,8 @@
 
       %td
         %h4
-          - if (can? [:show], team) || (current_user.team_ids.include? team.id)
+          -#TODO: get this logic working in app/models/ability.rb
+          - if (can? [:show], team) || (current_user.team_ids.include? team.id) || (current_user.is? :refunder)
             = link_to team.name, team_url(team)
           - else
             = team.name
@@ -54,7 +55,7 @@
           = team.description
 
       %td
-        - if current_user.is_any_of?(:admin, :operator)
+        - if current_user.is_any_of?(:admin, :operator, :refunder)
           %h4
             = team.assigned_team_number
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
   list: List
   back: Back
   refund: Refund
+  refund_and_invalidate: Refund & Remove
   at: at
   or: or
   of: of

--- a/lib/stripe_helper.rb
+++ b/lib/stripe_helper.rb
@@ -56,8 +56,6 @@ class StripeHelper
       hash
     end
 
-    private
-
     def log_and_return_error(ex)
       Rails.logger.error(exception_to_hash(ex).to_json)
       [false, ex]

--- a/spec/models/completed_requirement_spec.rb
+++ b/spec/models/completed_requirement_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
+require 'stripe_mock'
 
 describe CompletedRequirement do
+
+  let(:stripe_helper) { StripeMock.create_test_helper }
 
   describe '#metadata' do
     let (:hash) {{ 'foo' => 'bar' }}
@@ -36,7 +39,71 @@ describe CompletedRequirement do
                :requirement => rr.requirement, :user => FactoryGirl.create(:user2))
         .to be_invalid
       end
+    end
+  end
 
+  describe '#delete_by_charge' do
+
+    let(:cr)   { FactoryGirl.create :completed_requirement }
+    let(:req)  { cr.requirement }
+    let(:team) { cr.team }
+
+    let(:customer) do
+      Stripe::Customer.create({
+        card: stripe_helper.generate_card_token,
+        email: team.user.email,
+        metadata: {
+        user_id: team.user.id
+      }
+      })
+    end
+
+    let(:charge) do
+      Stripe::Charge.create({
+        customer:    customer.id,
+        amount:      7000,
+        currency:    'usd',
+        description: 'Registration Fee for Arizona Quints | Chiditarod X',
+        metadata: {
+          race_name: team.race.name,
+          team_name: team.name,
+          requirement_id: req.id,
+          team_id: team.id
+        }
+      })
+    end
+
+    before { StripeMock.start }
+    after  { StripeMock.stop  }
+
+    context 'when the completed requirement is found' do
+      it 'is destroyed' do
+        expect(CompletedRequirement).to receive(:destroy).with(cr)
+        CompletedRequirement.delete_by_charge(charge)
+      end
+    end
+
+    context 'when the completed requirement is not found' do
+
+      let(:charge) do
+        Stripe::Charge.create({
+          customer:    customer.id,
+          amount:      7000,
+          currency:    'usd',
+          description: 'Registration Fee for Arizona Quints | Chiditarod X',
+          metadata: {
+            race_name: team.race.name,
+            team_name: team.name,
+            requirement_id: (cr.requirement_id + 1),
+            team_id: team.id
+          }
+        })
+      end
+
+      it 'is not destroyed' do
+        expect(CompletedRequirement).to_not receive(:destroy).with(cr)
+        CompletedRequirement.delete_by_charge(charge)
+      end
     end
   end
 end


### PR DESCRIPTION
This keeps the team intact after the refund, and still counts it as being registered
Move logic to delete a completed requirement by charge into the CompletedRequirements model
Destroy instead of delete the completed requirement
Specs for CompletedRequirement.delete_by_charge and charges controller
`.includes(:people)` so registrations view is more performant