### PR TITLE
Configure tests to work with postgres docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,22 @@ Ensure it has the following variables.
 ### Build and run all containers
 
     docker-compose up -d
-    
-### Empty Database Setup
+
+### Create and Migrate Databases
 
     docker-compose exec web bundle exec rake db:create db:migrate
     docker-compose exec web sh -c 'RAILS_ENV=test bundle exec rake db:create db:migrate'
-    
+
 ### Connect to postgres inside container
 
     docker-compose exec db psql -U postgres
 
 ### Run the test suite
 
-    docker-compose exec app bundle exec rspec
+_Both assume a postgres container is running._
+
+    docker-compose exec web bundle exec rspec  # from within the web container
+    bundle exec rspec                          # from the console
 
 ### Restore postgres db from a dump file
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,6 +23,9 @@ test:
   encoding: unicode
   database: dogtag_test
   pool: 5
+  user: postgres
+  password: 123abc
+  host: localhost
 
 production:
   adapter: postgresql


### PR DESCRIPTION
Add default db connection options for test db to work with a locally-running pg docker container.