### PR TITLE
Refactor finalize/unfinalize logic out of team#show controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ vendor/bundle
 # SimpleCov code coverage report
 /coverage/
 /.env
+/.env-local
 
 # PostgreSQL dumps
 *.dump

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,6 @@ group :production do
   gem 'honeybadger'
 end
 
-# -------------------------------------------------------
-# BEGIN dogtag gems
-
 gem 'authlogic',  '~> 3.4.6'   # authentication
 gem 'cancancan', '~> 1.10'     # authorization, w/ Rails 4.2 support
 gem 'role_model', '~> 0.8.2'   # roles
@@ -26,8 +23,8 @@ gem 'json-schema'               # validate incoming jsonform
 # google analytics
 gem 'rack-tracker'
 
-# END dogtag gems
-# -------------------------------------------------------
+# pub/sub
+gem 'wisper-activerecord'
 
 gem 'nokogiri', '~> 1.8.1'
 
@@ -85,6 +82,8 @@ group :test, :development do
   gem 'test-unit'
   gem 'rspec'
   gem 'rspec-rails'
+  gem 'wisper-rspec'
+  gem 'test_after_commit' # required to test wisper pub/sub until rails 5+
   gem 'factory_bot_rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,6 +291,8 @@ GEM
     temple (0.8.0)
     test-unit (3.2.7)
       power_assert
+    test_after_commit (1.1.0)
+      activerecord (>= 3.2)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -320,6 +322,11 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    wisper (2.0.0)
+    wisper-activerecord (1.0.0)
+      activerecord (>= 3.0.0)
+      wisper (~> 2.0)
+    wisper-rspec (1.0.0)
     zonebie (0.6.1)
 
 PLATFORMS
@@ -362,16 +369,19 @@ DEPENDENCIES
   stripe (~> 1.31.0)
   stripe-ruby-mock (~> 2.3.1)
   test-unit
+  test_after_commit
   therubyracer
   timecop
   uglifier (>= 1.3.0)
   unicorn (~> 5.2)
   web-console (~> 3.0)
   webmock
+  wisper-activerecord
+  wisper-rspec
   zonebie
 
 RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.6
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -7,27 +7,20 @@ dogtag
 [![Test Coverage](https://codeclimate.com/github/chiditarod/dogtag/badges/coverage.svg)](https://codeclimate.com/github/chiditarod/dogtag/coverage)
 [![Code Climate](https://codeclimate.com/github/chiditarod/dogtag.png)](https://codeclimate.com/github/chiditarod/dogtag)
 
-Features
+Integrations
 --------
-- Payments/Refunds with Stripe API
-- Classy API integration to auto-setup a team's fundrasier campaigns.
+- Payments/Refunds via the Stripe API
+- Fundraising campaign automation via the Classy API
 
 Requirements
 ------------
 - App Server like Heroku
-- Redis
-- PostgreSQL
+- Redis (3.2)
+- PostgreSQL (9.4)
 - SMTP Server
 
 Docker Developer Setup
 ----------------------
-
-### Create your local .env file
-
-Ensure it has the following variables.
-
-    STRIPE_PUBLISHABLE_KEY=pk_test_....
-    STRIPE_SECRET_KEY=sk_test_....
 
 ### Build and run all containers
 
@@ -44,8 +37,7 @@ Ensure it has the following variables.
 
 ### Run the test suite
 
-_Both assume a postgres container is running._
-
+    docker-compose start db
     docker-compose exec web bundle exec rspec  # from within the web container
     bundle exec rspec                          # from the console
 
@@ -56,9 +48,23 @@ docker cp /local/file.dump $(docker-compose ps -q  db):/file.dump
 docker-compose exec db pg_restore -U postgres --verbose --clean --no-acl --no-owner -h localhost -d dogtag_development /file.dump
 ```
 
+### Boot local rails server/console
+
+    CLASSY_CLIENT_* environment variables are optional.
+
+```bash
+docker-compose start db redis mailcatcher
+CLASSY_CLIENT_ID=abc123 \
+CLASSY_CLIENT_SECRET=abc123 \
+DATABASE_URL=postgres://postgres:123abc@localhost:5432 \
+STRIPE_PUBLISHABLE_KEY=pk_test_abc123 \
+STRIPE_SECRET_KEY=sk_test_abc123 \
+bundle exec rails [s|c]
+```
+
 Developer Setup
 ---------------
-*Assumes an OSX environment. If you do it in Windows or Linux, please send us instructions and we will include them.*
+Tested on an OSX environment. If you do it in Windows or Linux and send us instructions, we will add them here.*
 
 1. Setup your Ruby environment by installing [Homebrew](https://github.com/Homebrew/homebrew) and [rbenv](https://github.com/rbenv/rbenv).
 
@@ -80,12 +86,17 @@ Developer Setup
         CLASSY_CLIENT_ID=<...>                # if you are using classy
         CLASSY_CLIENT_SECRET=<...>            # if you are using classy
 
-1. Run local daemons
+1. Run back-end services
+
+	*Docker makes it considerably easier to use these back-end services in local development.  Consult the Docker section above vs. installing them manually onto your workstation.*
 
         redis-server
         postgres -D /usr/local/var/postgres
-        bundle exec sidekiq -t 10 -C ./config/sidekiq.yml
         bundle exec mailcatcher
+
+1. Run dogtag deamons
+
+        bundle exec sidekiq -t 10 -C ./config/sidekiq.yml
         bundle exec rails s
 
 1. Run the test suite

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -19,12 +19,14 @@ class PeopleController < ApplicationController
 
   def destroy
     @person = Person.find params[:id]
+    @person.subscribe(PersonAuditor.new)
     try_to_delete(@person, team_url(id: @person.team.id))
   end
 
   def update
     @person = Person.includes(:team).find(params[:id])
     @team = @person.team
+    @person.subscribe(PersonAuditor.new)
     try_to_update(@person, person_params, team_url(@person.team.id))
   end
 
@@ -42,7 +44,8 @@ class PeopleController < ApplicationController
     return render :status => 400 if params[:person].blank?
 
     @team = Team.find params[:team_id]
-    @person = Person.new person_params
+    @person = Person.new(person_params)
+    @person.subscribe(PersonAuditor.new)
     @person.team = @team
 
     if @person.save

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -44,7 +44,8 @@ class TeamsController < ApplicationController
   def create
     return render :status => 400 if params[:team].blank?
 
-    @team = Team.new team_params
+    @team = Team.new(team_params)
+    @team.subscribe(TeamAuditor.new)
 
     @team.user = current_user
     race_id = params[:race_id] || session[:signup_race_id]
@@ -52,7 +53,7 @@ class TeamsController < ApplicationController
 
     if @team.save
       flash.now[:notice] = I18n.t('create_success')
-      return redirect_to team_questions_path(@team)
+      redirect_to team_questions_path(@team)
     else
       flash.now[:error] = [t('create_failed')]
       flash.now[:error] << @team.errors.messages
@@ -61,14 +62,11 @@ class TeamsController < ApplicationController
 
   def show
     @team = Team.find params[:id]
-
-    # check and do stuff if this team is now unfinalized for some reason
-    unprocess_if_newly_unfinalized
-
-    # check if the team now meets all finalization criteria and do stuff if so
-    process_if_newly_finalized
-
     @race = @team.race
+
+    if @team.finalized && @team.user == current_user
+      @display_notification = :notify_now_complete
+    end
 
     # currently required by charges controller to know where to redirect
     # the user after performing an action
@@ -78,14 +76,25 @@ class TeamsController < ApplicationController
   alias edit show
 
   def update
-    @team = Team.find params[:id]
+    @team = Team.find(params[:id])
+    @team.subscribe(TeamAuditor.new)
     @race = @team.race
-    try_to_update(@team, team_params, team_questions_path(@team))
+
+    @team.on(:update_team_successful) do |team|
+      flash[:notice] = I18n.t('update_success')
+      redirect_to(team_questions_path(team))
+    end
+    @team.on(:update_team_failed) do |team|
+      flash.now[:error] = [I18n.t('update_failed')]
+      flash.now[:error] << team.errors.messages
+    end
+    @team.update_attributes(team_params)
   end
 
   # TODO: only allow delete if no payments
   def destroy
     @team = Team.find params[:id]
+    @team.subscribe(TeamAuditor.new)
     try_to_delete(@team, teams_path)
   end
 
@@ -95,22 +104,5 @@ class TeamsController < ApplicationController
     params
       .require(:team)
       .permit(:race_id, :name, :description, :experience)
-  end
-
-  def process_if_newly_finalized
-    # precaution to ensure the team cannot be finalized unless by the owner or an admin-style user
-    return unless (current_user == @team.user || current_user.is_any_of?(:admin, :operator))
-
-    if @team.finalize
-      @display_notification = :notify_now_complete
-      @team.reload
-    end
-  end
-
-  def unprocess_if_newly_unfinalized
-    if !@team.meets_finalization_requirements? && @team.finalized
-      @team.unfinalize
-      @team.reload
-    end
   end
 end

--- a/app/listeners/person_auditor.rb
+++ b/app/listeners/person_auditor.rb
@@ -1,0 +1,16 @@
+class PersonAuditor
+  def create_person_successful(person)
+    refresh(person.team)
+  end
+
+  def destroy_person_successful(person)
+    refresh(person.team)
+  end
+
+  private
+
+  def refresh(team)
+    team.reload
+    team.finalize || team.unfinalize
+  end
+end

--- a/app/listeners/team_auditor.rb
+++ b/app/listeners/team_auditor.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 Devin Breen
+# Copyright (C) 2018 Devin Breen
 # This file is part of dogtag <https://github.com/chiditarod/dogtag>.
 #
 # dogtag is free software: you can redistribute it and/or modify
@@ -13,24 +13,21 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with dogtag.  If not, see <http://www.gnu.org/licenses/>.
-module Workers
-  # Run post-finalization tasks
-  class TeamFinalizer
-    include Sidekiq::Worker
-    include Workers::Common
 
-    sidekiq_options queue: :important, retry: true, backtrace: true
-    sidekiq_options failures: true
+class TeamAuditor
 
-    def run(job, data={})
-      job_email = Workers::TeamFinalizedEmail.perform_async({team_id: job['team_id']})
-      job_classy = Workers::ClassyCreateFundraisingTeam.perform_async({team_id: job['team_id']})
+  def create_team_successful(team)
+    refresh(team)
+  end
 
-      data[:child_job_ids] = {
-        team_finalized_email: job_email,
-        classy_create_fundraising_team: job_classy
-      }
-      log("complete", data)
-    end
+  def update_team_successful(team)
+    refresh(team)
+  end
+
+  private
+
+  def refresh(team)
+    team.reload
+    team.finalize || team.unfinalize
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -22,6 +22,8 @@ class Person < ActiveRecord::Base
   validates :experience, :numericality => { :only_integer => true, :greater_than_or_equal_to => 0 }
   validates_with PersonValidator, :on => :create
 
+  include Wisper.model
+
   belongs_to :team
 
   def self.registered_for_race(race_id)

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -51,7 +51,9 @@ class Requirement < ActiveRecord::Base
       :requirement_id => id,
       :team_id => team_id,
       :user => user,
-      :metadata => JSON.generate(metadata))
+      :metadata => JSON.generate(metadata)
+    )
+    cr.subscribe(CompletedRequirementAuditor.new)
     return cr if cr.save
     false
   end

--- a/app/views/requirements/_payment_requirement_table.html.haml
+++ b/app/views/requirements/_payment_requirement_table.html.haml
@@ -1,11 +1,14 @@
 .page-header
+
   %h1
+    = link_to new_tier_url(:requirement_id => @requirement.id) do
+      %i.fa.fa-plus
     = t('.payment_tiers')
-    %small
-      = @requirement.tiers.count
-      = t('configured')
-      = link_to new_tier_url(:requirement_id => @requirement.id) do
-        %i.fa.fa-plus
+    - if @requirement.tiers.present?
+      %small
+        \-
+        = @requirement.tiers.count
+
 
 - if @requirement.tiers.blank?
   = t ('.no_tiers_added')

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,7 @@ module RailsSkeleton
     config.filter_parameters << :password
 
     config.autoload_paths += %W(#{config.root}/lib)
+
+    config.active_record.raise_in_transactional_callbacks = true
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,7 +54,6 @@ en:
   or: or
   of: of
   for: for
-  configured: configured
   closed: Closed
   status: 'Status:'
   complete: Complete

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ services:
       - db
     env_file:
       - .env-development
-      - .env
     networks:
       - web
     volumes:
@@ -60,7 +59,7 @@ services:
     volumes:
       - bundle_cache:/bundle_cache
     ports:
-      - "1025"
+      - "1025:1025"
       - "1080:1080"
 
 networks:

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -76,6 +76,12 @@ describe PeopleController do
         end.to change(Person, :count).by(-1)
       end
 
+      it 'broadcasts when destroying the record' do
+        expect do
+          delete :destroy, :team_id => team.id, :id => team.people.first.id
+        end.to broadcast(:destroy_person_successful)
+      end
+
       # we don't want to remove a person record once we reach the correct number, as
       # it would cause the team to no longer be complete
       context 'when team requirements are all met' do
@@ -190,6 +196,12 @@ describe PeopleController do
         expect do
           post :create, :team_id => team_no_people.id, :person => new_person_hash
         end.to change(Person, :count).by 1
+      end
+
+      it 'broadcasts when creating the record' do
+        expect do
+          post :create, :team_id => team_no_people.id, :person => new_person_hash
+        end.to broadcast(:create_person_successful)
       end
 
       context 'upon success' do

--- a/spec/listeners/completed_requirement_auditor_spec.rb
+++ b/spec/listeners/completed_requirement_auditor_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe "CompletedRequirementAuditor" do
+
+  let(:user) { FactoryBot.create :user }
+  let(:req)  { FactoryBot.create :enabled_payment_requirement }
+  let(:cr)   { FactoryBot.build :cr, requirement: req, team: team, user: user }
+
+  before do
+    cr.subscribe(CompletedRequirementAuditor.new)
+  end
+
+  context "a completed requirement gets created and the team now meets all requirements" do
+    let(:team) { FactoryBot.create :team, :with_enough_people, race: req.race, user: user }
+
+    it "the team becomes finalized" do
+      expect(team.finalized?).to be false
+      cr.save
+      expect(team.reload.finalized?).to be true
+    end
+  end
+
+  context "a completed requirement gets created but the team does not meet all requirements" do
+    let(:team) { FactoryBot.create :team, :with_people, race: req.race, user: user }
+
+    it "the team stays unfinalized" do
+      expect(team.finalized?).to be false
+      cr.save
+      expect(team.reload.finalized?).to be false
+    end
+  end
+
+  context "a completed requirement associated with a finalized team gets deleted" do
+    let(:team) { FactoryBot.create :team, :with_enough_people, race: req.race }
+    let(:cr)   { FactoryBot.create :cr, requirement: req, team: team, user: user }
+    it "the team becomes unfinalized" do
+      team.finalize
+      expect(team.finalized?).to be true
+      cr.destroy
+      expect(team.reload.finalized?).to be false
+    end
+  end
+end

--- a/spec/listeners/person_auditor_spec.rb
+++ b/spec/listeners/person_auditor_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe "PersonAuditor" do
+
+  before do
+    person.subscribe(PersonAuditor.new)
+  end
+
+  context "a person gets created and the team is now full" do
+    let(:team) { FactoryBot.create :team, :with_people }
+    let(:person) { FactoryBot.build :person, team_id: team.id }
+
+    it "the team becomes finalized" do
+      expect(team.finalized?).to be false
+      person.save
+      expect(team.reload.finalized?).to be true
+    end
+  end
+
+  context "a person gets created on a team that does not meet all finalization requirements" do
+    let(:team) { FactoryBot.create :team }
+    let(:person) { FactoryBot.build :person, team_id: team.id }
+
+    it "the team stays unfinalized" do
+      expect(team.finalized?).to be false
+      person.save
+      expect(team.reload.finalized?).to be false
+    end
+  end
+
+  context "a person on a finalized team gets deleted" do
+    let(:team) { FactoryBot.create :finalized_team }
+    let(:person) { team.people.first }
+
+    it "the team becomes unfinalized" do
+      expect(team.finalized?).to be true
+      person.destroy
+      expect(team.reload.finalized?).to be false
+    end
+  end
+end

--- a/spec/listeners/team_auditor_spec.rb
+++ b/spec/listeners/team_auditor_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe "TeamAuditor" do
+
+  before do
+    team.subscribe(TeamAuditor.new)
+  end
+
+  describe ".create_team_successful" do
+
+    let(:race) { FactoryBot.create :race }
+    let(:team) { FactoryBot.build :team, race: race }
+
+    context "an unfinalized team is created" do
+      it "does not show as finalized" do
+        expect(team.finalized?).to be false
+        team.save
+        expect(team.finalized?).to be false
+      end
+    end
+
+    context "a finalized team is created" do
+      it "shows as finalized" do
+        team.race.people_per_team.times do |i|
+          team.people << FactoryBot.create(:person)
+        end
+
+        expect(team.finalized?).to be false
+        team.save
+        expect(team.finalized?).to be true
+      end
+    end
+  end
+
+  describe ".update_team_successful" do
+
+    context "an unfinalized team ready to be finalized is updated" do
+      let(:team) { FactoryBot.create :team, :with_enough_people }
+      it "the team becomes finalized" do
+        expect(team.finalized?).to be false
+        team.description = "foo"
+        team.save
+        expect(team.reload.finalized?).to be true
+      end
+    end
+
+    context "an unfinalized team not ready to be finalized is updated" do
+      let(:team) { FactoryBot.create :team, :with_people }
+
+      it "the team does not become finalized" do
+        expect(team.finalized?).to be false
+        team.description = "foo"
+        team.save
+        expect(team.reload.finalized?).to be false
+      end
+    end
+
+    context "a finalized team that still meets all finalization requirements is updated" do
+      let(:team) { FactoryBot.create :finalized_team }
+
+      it "the team does not become unfinalized" do
+        expect(team.finalized?).to be true
+        team.description = "foo"
+        team.save
+        expect(team.reload.finalized?).to be true
+      end
+    end
+
+    context "a finalized team that no longer meets all finalization requirements is updated" do
+      let(:team) { FactoryBot.create :finalized_team }
+
+      it "the team becomes unfinalized" do
+        expect(team.finalized?).to be true
+        team.people.first.destroy()
+        team.save
+        expect(team.reload.finalized?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/completed_requirement_spec.rb
+++ b/spec/models/completed_requirement_spec.rb
@@ -59,7 +59,7 @@ describe CompletedRequirement do
 
   describe '#delete_by_charge' do
 
-    let(:cr)   { FactoryBot.create :completed_requirement }
+    let!(:cr)  { FactoryBot.create :completed_requirement }
     let(:req)  { cr.requirement }
     let(:team) { cr.team }
 
@@ -93,8 +93,15 @@ describe CompletedRequirement do
 
     context 'when the completed requirement is found' do
       it 'is destroyed' do
-        expect(CompletedRequirement).to receive(:destroy).with(cr)
-        CompletedRequirement.delete_by_charge(charge)
+        expect do
+          CompletedRequirement.delete_by_charge(charge)
+        end.to change(CompletedRequirement, :count).by -1
+      end
+
+      it 'broadcasts when destroying' do
+        expect do
+          CompletedRequirement.delete_by_charge(charge)
+        end.to broadcast(:destroy_completed_requirement_successful)
       end
     end
 
@@ -116,8 +123,9 @@ describe CompletedRequirement do
       end
 
       it 'is not destroyed' do
-        expect(CompletedRequirement).to_not receive(:destroy).with(cr)
-        CompletedRequirement.delete_by_charge(charge)
+        expect do
+          CompletedRequirement.delete_by_charge(charge)
+        end.to change(CompletedRequirement, :count).by 0
       end
     end
   end

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -52,6 +52,12 @@ describe Requirement do
         requirement.complete team.id, user
       end.to change(CompletedRequirement, :count).by 1
     end
+
+    it 'broadcasts when creating' do
+      expect do
+        requirement.complete team.id, user
+      end.to broadcast(:create_completed_requirement_successful)
+    end
   end
 
   describe '#completed?' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ require 'webmock/rspec'
 require "zonebie/rspec"
 require 'rspec/rails'
 require 'sidekiq/testing'
+require 'wisper/rspec/matchers'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -36,6 +37,9 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
 RSpec.configure do |config|
+
+  config.include(Wisper::RSpec::BroadcastMatcher)
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
Refactor the team#show logic responsible for finalizing and unfinalizing a teams.  Remove it from the controller into the model. Add some sort of observer or pub/sub pattern to detect changes in a team, person, or completed requirement so the finalization status of the team can be evaluated when those changes happen. 