### PR TITLE
Protect /sidekiq endpoint under basic http auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Tested on an OSX environment. If you do it in Windows or Linux and send us instr
         REDIS_URL=<...>                       # default: redis://127.0.0.1:6379
         CLASSY_CLIENT_ID=<...>                # if you are using classy
         CLASSY_CLIENT_SECRET=<...>            # if you are using classy
+        SIDEKIQ_USER=<...>                    # include to protect /sidekiq route behind http basic auth
+        SIDEKIQ_PASS=<...>                    # include to protect /sidekiq route behind http basic auth
 
 1. Run back-end services
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -23,3 +23,14 @@ end
 Sidekiq.configure_client do |config|
   config.redis = { url: redis_url }
 end
+
+# password-protect the /sidekiq route
+
+if ENV['SIDEKIQ_USER'] && ENV['SIDEKIQ_PASS']
+  require 'sidekiq'
+  require 'sidekiq/web'
+
+  Sidekiq::Web.use(Rack::Auth::Basic) do |user, password|
+    [user, password] == [ENV['SIDEKIQ_USER'], ENV['SIDEKIQ_PASS']]
+  end
+end


### PR DESCRIPTION
Per https://stackoverflow.com/questions/12265421/how-can-i-password-protect-my-sidekiq-route-i-e-require-authentication-for-th