### PR TITLE
Adds final_edits_close date, allowing racer data to be editable after reg close

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,11 +1,11 @@
 // First import theme variables
-@import "bootswatch/superhero/variables";
+@import "bootswatch/lumen/variables";
 
 // Then bootstrap
 @import "bootstrap";
 
 // And finally bootswatch style
-@import "bootswatch/superhero/bootswatch";
+@import "bootswatch/lumen/bootswatch";
 
 @import "tablesorter.theme.bootstrap";
 
@@ -20,20 +20,6 @@
   /*@extend .control-group;*/
   @extend .error;
 }
-
-select {
-  color: black;
-}
-
-input {
-  color: black;
-  background: #bbb;
-}
-
-button {
-  color: black;
-}
-
 
 .jsonform-errortext {
   color: red;
@@ -57,7 +43,6 @@ li.select2-results__option {
 
   .help-block {
     font-size: 115%;
-    background: #233241;
     padding: .3em;
   }
 }
@@ -68,4 +53,8 @@ label.control-label {
 .help-inline {
   font-size:85%;
   margin-left: 1em;
+}
+
+table.table {
+  font-size: 1.1em;
 }

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -39,7 +39,6 @@ class QuestionsController < ApplicationController
       return redirect_to team_path(@team)
     end
 
-    # manipulate the jsonform
     jsonform = JSON.parse(@team.race.jsonform)
     jsonform = JsonForm.add_csrf(jsonform, form_authenticity_token)
     jsonform = JsonForm.add_saved_answers(@team, jsonform, form_authenticity_token)
@@ -51,6 +50,7 @@ class QuestionsController < ApplicationController
     authorize! :create, :questions
     @team = Team.find(params[:team_id])
 
+    # todo: move this validation logic into model
     unless @team.race.open_for_registration?
       flash[:error] = I18n.t('questions.cannot_modify')
       return redirect_to team_path(@team)

--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -27,7 +27,7 @@ class RacesController < ApplicationController
   def show
     @race = Race.find params[:id]
     if current_user
-      @my_race_teams = @race.teams.where(:id => current_user.team_ids)
+      @my_race_teams = Team.belonging_to(current_user.id).where(race_id: @race.id)
       if current_user.is_any_of?(:admin, :operator)
         @stats = @race.stats
       end

--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -94,7 +94,7 @@ class RacesController < ApplicationController
     params.
       require(:race).
       permit(:name, :max_teams, :people_per_team,
-             :race_datetime, :registration_open, :registration_close,
+             :race_datetime, :registration_open, :registration_close, :final_edits_close,
              :classy_campaign_id, :classy_default_goal,
              :jsonform, {filter_field: []}
       )

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -34,7 +34,7 @@ class Person < ActiveRecord::Base
   def self.registered_for_race(race_id)
     race = Race.find race_id
     race.finalized_teams.inject([]) do |total, reg|
-      total.concat reg.people.reject{ |person| person.email.downcase =~ /unknown/}
+      total.concat(reg.people.reject{ |person| person.email.downcase =~ /unknown/})
     end
   end
 end

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -15,7 +15,7 @@
 # along with dogtag.  If not, see <http://www.gnu.org/licenses/>.
 class Race < ActiveRecord::Base
   validates_presence_of :name, :max_teams, :people_per_team
-  validates_presence_of :race_datetime, :registration_open, :registration_close
+  validates_presence_of :race_datetime, :registration_open, :registration_close, :final_edits_close
   validates :max_teams, :people_per_team, :numericality => {
     :only_integer => true,
     :greater_than => 0

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -89,12 +89,19 @@ class Race < ActiveRecord::Base
   def open_for_registration?
     now = Time.zone.now
     return false if now < registration_open
-    return false if registration_close < now
+    return false if now > registration_close
     true
   end
 
   def registration_over?
     registration_close < Time.zone.now
+  end
+
+  def in_final_edits_window?
+    now = Time.zone.now
+    return false if now < registration_close
+    return false if now > final_edits_close
+    true
   end
 
   def registerable?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -80,15 +80,14 @@ class Team < ActiveRecord::Base
     end
   end
 
-  # remove the finalization bits from the team
+  # this removes the finalization bits from the team
   # return nil if the team is not a candidate for unfinalization
   def unfinalize(force=false)
-    unless force
+    if ! force
       return nil unless finalized
       return nil if meets_finalization_requirements?
     end
 
-    # unset the notification field so they can be again notified in the future.
     self.notified_at = nil
     self.finalized = nil
     self.save

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -36,6 +36,7 @@ class Team < ActiveRecord::Base
 
   scope :all_finalized,   -> { where('teams.finalized = ?', true) }
   scope :all_unfinalized, -> { where('teams.finalized IS NULL') }
+  scope :belonging_to, ->(user_id) { where("user_id = ?", user_id) }
 
   EXPERIENCE_LEVELS = [
     "Zero. Fresh meat",

--- a/app/validators/person_validator.rb
+++ b/app/validators/person_validator.rb
@@ -15,7 +15,17 @@
 # along with dogtag.  If not, see <http://www.gnu.org/licenses/>.
 class PersonValidator < ActiveModel::Validator
   def validate(record)
-    validate_person_count record
+    ensure_editing_is_ok(record)
+    validate_person_count(record)
+  end
+
+  def ensure_editing_is_ok(record)
+    if record.team.present? && record.team.race.present?
+      race = record.team.race
+      if !(race.open_for_registration? || race.in_final_edits_window?)
+        record.errors[:generic] << "cannot edit this information after the final edit date"
+      end
+    end
   end
 
   def validate_person_count(record)

--- a/app/validators/race_validator.rb
+++ b/app/validators/race_validator.rb
@@ -16,20 +16,20 @@
 class RaceValidator < ActiveModel::Validator
 
   def validate(record)
-    validate_open_and_close_dates(record) if datetimes_parse?(record)
+    validate_dates(record) if datetimes_parse?(record)
   end
 
   private
 
-  def validate_open_and_close_dates(record)
+  def validate_dates(record)
+    unless record.final_edits_close < record.race_datetime
+      record.errors.add(:final_edits_close, 'must come before race_datetime')
+    end
+    unless record.registration_close < record.final_edits_close
+      record.errors.add(:registration_close, 'must come before final_edits_close')
+    end
     unless record.registration_open < record.registration_close
       record.errors.add(:registration_open, 'must come before registration_close')
-    end
-    unless record.registration_open < record.race_datetime
-      record.errors.add(:registration_open, 'must come before race_datetime')
-    end
-    unless record.registration_close < record.race_datetime
-      record.errors.add(:registration_close, 'must come before race_datetime')
     end
   end
 

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -1,16 +1,16 @@
 / Static navbar
 / view-source:http://getbootstrap.com/examples/navbar-static-top/
-.navbar.navbar-default{role: "navigation"}
-  .navbar-header
+.navbar.navbar-default
 
-    %button.navbar-toggle{"data-target" => ".navbar-collapse", "data-toggle" => "collapse", type: "button"}
+  .navbar-header
+    %button.navbar-toggle{"data-target" => "#navbarColor01", "data-toggle" => "collapse", type: "button"}
       %span.sr-only Toggle navigation
       %span.icon-bar
       %span.icon-bar
       %span.icon-bar
     = link_to(I18n.t('website_title'), home_url, :class => 'navbar-brand')
 
-  .navbar-collapse.collapse
+  .navbar-collapse.collapse#navbarColor01
     %ul.nav.navbar-nav
       %li
         = link_to races_path do
@@ -18,7 +18,6 @@
           = t('.races')
 
       - if current_user
-
         - if current_user.team_ids.present?
           %li
             = link_to teams_path do
@@ -36,11 +35,6 @@
               %li= link_to t('list'), users_path
               %li= link_to t('new'), new_user_path
               %li.divider
-
-      -#%li
-        %a{:"href" => '#shopify-store'}
-          %i.fa.fa-diamond.fa-2x
-          =t 'shop'
 
     %ul.nav.navbar-nav.navbar-right
       - if current_user

--- a/app/views/homepages/index.html.haml
+++ b/app/views/homepages/index.html.haml
@@ -1,72 +1,68 @@
 = javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/marked/0.2.9/marked.min.js"
 
-.jumbotron
-
-  .pull-right
-    %img{src: '/images/doge_circle_web.png'}
-
-  %i.fa.fa-shopping-cart.fa-5x.pull-left.fa-flip-horizontal
-  %h1 dogtag
-  %p
-    = t('.chiditarod_registration_system')
-
-  = link_to t('.get_started'), races_url, :class => ['btn', 'btn-success']
-
 .row
-  .col-md-6
-    %h4 Overview
-    %p
-      Welcome to dogtag. It allows your team to sign up for the race,
-      manage your team information, and pay your registration fee and cart deposit.  All from the comfort of home.
+  .col-xs-12
+    .text-center
+      %img{src: '/images/doge_circle_web.png'}
+      %h1
+        dogtag
+        .lead
+          = t('.chiditarod_registration_system')
+      = link_to t('.get_started'), races_url, :class => ['btn', 'btn-success']
+      %br
+      %br
 
-    %p
-      Once registered, you have until the close of registration to login and update and/or change this information.
-      Just visit
-      %a{:href=>'http://dogtag.chiditarod.org'} dogtag.chiditarod.org.
+.jumbotron
+  .row
+    .col-md-6
+      %p
+        %h4 Overview
+        Use dogtag to register for CHIditarod. Create an account, signup for the race, complete all of the requirements, receive confirmation
+        emails, prepare thyself, mush!
 
-    %p
-      Teams that fully complete their registration will be considered official racers. Partially-completed teams
-      (missing required details, people, or payments) are not considered official. We sell out every year, so make sure to
-      complete your team registration in-full, early.  Once all spots are filled, any remaining incomplete teams are
-      automatically put onto the waitlist. First come, first served. Teams on the waitlist will be contacted at the
-      close of race registration to determine if there is an open spot or not.
+        %br
+        %br
+        Teams that fully complete their registration will be considered official racers. Teams that do not fully complete
+        their registration and receive confirmation via the web and email are not allowed to race. Ensure you complete
+        all basics, details, payments and add the correct number of racers. Once registered, you have until the close of
+        registration to login and update and/or change this information.
 
-    -#%p
-      %a{:"href" => '#shopify-store'}
-        %i.fa.fa-diamond.fa-3x.pull-left
-        %h2
-          New Online Merch Depot!
+        %br
+        %br
+        Once all spots are filled, any remaining incomplete teams are automatically put onto the waitlist. First come,
+        first served. Teams on the waitlist will be contacted at the close of race registration to determine if there is an open spot or not.
 
-  .col-md-6
-    %h4 Racer Management
-    %p
-      You will need to sign up all 5 racers to complete your team. If you do not have all 5 racers yet, please
-      write
-      %b
-        unknown
-      into the fields of your missing racers.  If you have to take a racer out and put a new racer in
-      you just login and make the change.  Please do so BEFORE registration closes, and make it accurate.
-      We use all the email addresses to send important race information, and we will use text messaging on the day-of
-      for any critical details.
+    .col-md-6
+      %p
+        %h4 Racer Management
+        You will need to sign up all 5 racers to complete your team. If you do not have all 5 racers yet, please
+        write
+        %b
+          unknown
+        into the fields of your missing racers.  If you have to take a racer out and put a new racer in
+        you just login and make the change.  Please do so BEFORE registration closes, and make it accurate.
+        We use all the email addresses to send important race information, and we will use text messaging on the day-of
+        for any critical details.
 
-    %h4 System Requirements
-    %p
-      Please use Chrome or Firefox, and you
-      %strong
-        %u
-          must have JavaScript enabled.
-    %h4 Emails
-    %p
-      Also be aware that Heroku (the service that hosts dogtag) sends emails slowly, so it may take
-      up to 10 minutes to receive confirmation or password reset emails. We are working with them to
-      make this faster.
+      %p
+        %h4 System Requirements
+        Please use Chrome or Firefox, and you
+        %strong
+          %u
+            must have JavaScript enabled.
 
-    %p
-      %h4 Bugs?
-      We think we've ironed out any kinks from last year, but please help
-      %a{:href=>"http://github.com/chiditarod/dogtag/issues/new/"}
-        report bugs
-      if you encounter any and we'll get right on them.
+      %p
+        %h4 Emails
+        Also be aware that Heroku (the service that hosts dogtag) sends emails slowly, so it may take
+        up to 10 minutes to receive confirmation or password reset emails. We are working with them to
+        make this faster.
+
+      %p
+        %h4 Bugs?
+        We think we've ironed out any kinks from last year, but please help
+        %a{:href=>"http://github.com/chiditarod/dogtag/issues/new/"}
+          report bugs
+        if you encounter any and we'll get right on them.
 
 
 

--- a/app/views/people/_table.html.haml
+++ b/app/views/people/_table.html.haml
@@ -10,7 +10,7 @@
   - people.each do |person|
     %tr
       %td
-        - if person.team.race.open_for_registration? || current_user.is_any_of?(:admin, :operator)
+        - if current_user.is_any_of?(:admin, :operator) || race.open_for_registration? || race.in_final_edits_window?
           = link_to(edit_team_person_url :team_id => person.team.id, :id => person.id) do
             %i.fa.fa-edit.fa-2x
         - if current_user.is? :admin

--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -1,8 +1,0 @@
-.page-header
-  %h1
-    = t('.title')
-
-- if @people.blank?
-  = t ('.no_people_added')
-- else
-  = render 'table', :people => @people

--- a/app/views/races/_form.html.haml
+++ b/app/views/races/_form.html.haml
@@ -26,6 +26,13 @@
 
   .form-group
     .col-sm-4.control-label
+      = label_tag :final_edits_close, t('.final_edits_close')
+    .col-sm-8
+      = f.datetime_select :final_edits_close, :include_seconds => true, :class => 'form-control'
+      = Time.zone
+
+  .form-group
+    .col-sm-4.control-label
       = label_tag :race_datetime, t('.race_datetime')
     .col-sm-8
       = f.datetime_select :race_datetime, :class => 'form-control'
@@ -70,4 +77,3 @@
   .form-group
     .col-sm-offset-4.col-sm-8
       = f.submit t('save'), :class => ['btn', 'btn-default']
-

--- a/app/views/races/edit.html.haml
+++ b/app/views/races/edit.html.haml
@@ -2,7 +2,6 @@
   .col-sm-12
     = render 'form'
 
-
 .page-header
   %h3
     = t('.race_requirements')
@@ -13,4 +12,4 @@
 - if @race.requirements.blank?
   = t ('.no_requirements_added')
 - else
-  = render 'requirements/table', :requirements => @race.requirements
+  = render 'requirements/table', :requirements => @race.requirements, :race_id => @race.id

--- a/app/views/requirements/_payment_requirement.html.haml
+++ b/app/views/requirements/_payment_requirement.html.haml
@@ -45,4 +45,7 @@
 
   - else
     %i.lead.text-danger
+      %i.fa.fa-lock.fa-5x
+      /= payment system locked when registration is closed
+      %br
       = t('.no_complete_when_closed')

--- a/app/views/requirements/_table.html.haml
+++ b/app/views/requirements/_table.html.haml
@@ -6,19 +6,19 @@
       %th= t('enabled')
       %th= t('details')
       %th
-  - requirements.each do |requirement|
+  - requirements.each do |req|
     %tr
       %td
-        = link_to(edit_race_requirement_url :race_id => requirement.race.id, :id => requirement.id) do
+        = link_to(edit_race_requirement_url(:race_id => race_id, :id => req.id)) do
           %i.fa.fa-edit.fa-2x
-      %td= button_to t('delete'), race_requirement_url(:race_id => requirement.race.id, :id => requirement.id), :method=>:delete,  :data => { :confirm => 'Are you sure?' }
-      %td= requirement.name
+      %td= button_to t('delete'), race_requirement_url(:race_id => race_id, :id => req.id), :method => :delete,  :data => { :confirm => 'Are you sure?' }
+      %td= req.name
       %td
-        - if requirement.enabled?
+        - if req.enabled?
           %i.fa.fa-check.fa-2x
         - else
-          = link_to t('action_required'), (edit_race_requirement_url :race_id => requirement.race.id, :id => requirement.id)
+          = link_to t('action_required'), (edit_race_requirement_url(:race_id => race_id, :id => req.id))
       %td
-        - if requirement.type == 'PaymentRequirement'
-          = requirement.tiers.count
+        - if req.type == 'PaymentRequirement'
+          = req.tiers.count
           = t '.tiers'

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -26,17 +26,9 @@
     .row
       %h1
         = @team.name
-        - if @team.race.open_for_registration? || current_user.is_any_of?(:admin, :operator)
-          %small
-            = link_to edit_team_path(@team.id) do
-              .fa.fa-edit
-              = t('.edit')
 
       %h4
-        - if @team.finalized
-          = t('.registered_for')
-        - else
-          = t('.registering_for')
+        = t('.race')
         = link_to @race.name, race_path(@race)
 
         - if @team.assigned_team_number && current_user.is_any_of?(:admin, :operator)
@@ -45,7 +37,11 @@
           = @team.assigned_team_number
 
       - if @team.race.open_for_registration?
-        = t('.can_change_until', :date => @race.registration_close.strftime('%B %e, %Y'))
+        %i.lead.text-success
+          = t('.can_change_until', :date => @race.registration_close.strftime('%B %e, %Y'))
+      - elsif @team.race.in_final_edits_window?
+        %i.lead.text-warning
+          = t('.final_edits_until', :date => @race.final_edits_close.strftime('%B %e, %Y'))
       - else
         %i.lead.text-danger
           = t('.registration_closed')
@@ -60,39 +56,47 @@
 %ul.nav.nav-tabs
   %li.active
     %a{"href" => "#people", "data-toggle" => "tab"}
-      =t('.people')
-
       - if @team.needs_people?
         .text-danger.fa.fa-frown-o
       - else
         %i.fa.fa-smile-o.text-success
+      =t('.people')
 
   %li
     %a{"href" => "#requirements", "data-toggle" => "tab"}
-      =t('.payments')
       - if @team.completed_all_requirements?
         .text-success.fa.fa-smile-o
       - else
         .text-danger.fa.fa-frown-o
+      = t('.payments')
 
   %li
-    = link_to t('.basics'), edit_team_path(@team)
+    - if @team.race.open_for_registration? || current_user.is_any_of?(:admin, :operator)
+      = link_to edit_team_path(@team) do
+        %span.text-success.fa.fa-smile-o
+        = t('.basics')
+
+    - else
+      %a{:href => '#'}
+        %span.text-success.fa.fa-smile-o
+        = t('.basics')
 
   %li
     - if @team.race.open_for_registration? || current_user.is_any_of?(:admin, :operator)
       = link_to team_questions_path(@team) do
-        = t('.details')
         - if @team.race.jsonform.present? && @team.jsonform.blank?
           .text-danger.fa.fa-frown-o
         - else
           .text-success.fa.fa-smile-o
+        = t('.details')
+
     - else
       %a{:href => '#'}
-        =t('.details')
         - if @team.race.jsonform.present? && @team.jsonform.blank?
           .text-danger.fa.fa-frown-o
         - else
           .text-success.fa.fa-smile-o
+        =t('.details')
 
 .tab-content
 
@@ -101,6 +105,7 @@
 
   .tab-pane.active{:id => "people"}
 
+    -#todo: consider delete; can't see it render
     - if @team.needs_people?
       .pull-right
         .text-danger
@@ -119,29 +124,31 @@
       %br
       = @team.user.email
 
-    %h3
+    %h2
+      - if @team.needs_people?
+        - if @team.race.open_for_registration? || current_user.is_any_of?(:admin, :operator)
+          = link_to new_team_person_url(@team.id) do
+            %i.fa.fa-plus.fa-2x
+      - else
+        %i.fa.fa-smile-o.text-success
+
       %i.fa.fa-user
       = t('.people')
       %small
+        [
         = @team.people.count
         = t('of')
         = @team.race.people_per_team
-
-        - if @team.needs_people?
-          - if @team.race.open_for_registration? || current_user.is_any_of?(:admin, :operator)
-            = link_to new_team_person_url(@team.id) do
-              %i.fa.fa-plus
-        - else
-          %i.fa.fa-smile-o.text-success
-
-    = t('.people_instructions')
-    %br
+        ]
 
     - if @team.people.blank?
       %br
       .lead= t ('.no_people_added')
     - else
-      = render 'people/table', :people => @team.people
+      = render 'people/table', :people => @team.people, :race => @team.race
+
+    %br
+    = t('.people_instructions')
 
   -#-----------------------------------------------------------
   -# requirements  (consider partial

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -6,14 +6,9 @@ Rollbar.configure do |config|
 
   config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
 
-  # Here we'll disable in 'test':
-  if Rails.env.test?
+  unless Rails.env.production?
     config.enabled = false
   end
-
-
-
-
 
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object's `id`,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,8 +223,11 @@ en:
       edit: edit
       requirements: Payments
       status: Team Status
+      race: "Race:"
       registered_for: Registered for
-      can_change_until: "You can update this information until registration closes on %{date}."
+      registration_closed: "Registration closed. No further updates are possible."
+      can_change_until: "Finish all registration steps by %{date}"
+      final_edits_until: "Registration closed. Racer details are editable until %{date}"
 
       description: "Your Mission:"
       people: Racers
@@ -254,7 +257,7 @@ en:
   requirements:
     payment_requirement:
       no_pay_waitlist: You are on the waitlist. Payment is not available.
-      no_complete_when_closed: Cannot pay when closed.
+      no_complete_when_closed: Registration closed
     table:
       tiers: tiers
 

--- a/db/migrate/20180219041406_add_final_edits_close.rb
+++ b/db/migrate/20180219041406_add_final_edits_close.rb
@@ -1,0 +1,18 @@
+class AddFinalEditsClose < ActiveRecord::Migration
+  def up
+    add_column :races, :final_edits_close, :datetime
+
+    # add a default value to all existing records
+    execute <<-SQL
+      UPDATE races
+      SET final_edits_close = registration_close + INTERVAL '1 hour';
+    SQL
+
+    # now set the field to not allow null
+    change_column_null :races, :final_edits_close, false
+  end
+
+  def down
+    remove_column :races, :final_edits_close
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,18 +1,3 @@
-# Copyright (C) 2013 Devin Breen
-# This file is part of dogtag <https://github.com/chiditarod/dogtag>.
-#
-# dogtag is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# dogtag is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with dogtag.  If not, see <http://www.gnu.org/licenses/>.
 # encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
@@ -26,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170116085249) do
+ActiveRecord::Schema.define(version: 20180219041406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +54,7 @@ ActiveRecord::Schema.define(version: 20170116085249) do
     t.string   "filter_field",        limit: 255
     t.integer  "classy_campaign_id"
     t.integer  "classy_default_goal"
+    t.datetime "final_edits_close",               null: false
   end
 
   create_table "requirements", force: :cascade do |t|

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -300,6 +300,8 @@ describe TeamsController do
         end
       end
 
+      context 'when validation fails on update'
+
       context 'with valid patch data' do
         let(:team) { FactoryBot.create :team }
 

--- a/spec/factories/race.rb
+++ b/spec/factories/race.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
     sequence(:name) { |n| "Race #{n}" }
     registration_open (Time.zone.now - 2.weeks)
     registration_close (Time.zone.now + 2.weeks)
+    final_edits_close (Time.zone.now + 3.weeks)
     race_datetime (Time.zone.now + 4.weeks)
     max_teams 3
     people_per_team 2
@@ -40,14 +41,9 @@ FactoryBot.define do
       end
     end
 
-    factory :race_with_classy_data do
+    trait :with_classy_data do
       classy_campaign_id 12345
       classy_default_goal 2000
-    end
-
-    factory :ended_race do
-      registration_close (Time.zone.now - 1.week)
-      race_datetime (Time.zone.now - 1.day)
     end
 
     trait :registration_closed do
@@ -60,6 +56,16 @@ FactoryBot.define do
 
     trait :registration_closing_now do
       registration_close Time.zone.now
+    end
+
+    trait :in_final_edits_window do
+      registration_close (Time.zone.now - 1.day)
+      final_edits_close (Time.zone.now + 1.day)
+    end
+
+    trait :after_final_edits_window do
+      registration_close (Time.zone.now - 2.days)
+      final_edits_close (Time.zone.now - 1.day)
     end
   end
 end

--- a/spec/factories/team.rb
+++ b/spec/factories/team.rb
@@ -26,10 +26,8 @@ FactoryBot.define do
 
     factory :finalized_team do
       after(:create) do |team|
-        Timecop.freeze(THE_TIME) do
-          create_list(:person, team.race.people_per_team, team: team)
-          team.finalize
-        end
+        create_list(:person, team.race.people_per_team, team: team)
+        team.finalize
       end
     end
 

--- a/spec/factories/tier.rb
+++ b/spec/factories/tier.rb
@@ -16,7 +16,7 @@
 FactoryBot.define do
   factory :tier do
     transient do
-      thetime { Timecop.freeze(THE_TIME) { Time.zone.now } }
+      thetime { Time.zone.now }
     end
 
     price 5000

--- a/spec/lib/classy_client_spec.rb
+++ b/spec/lib/classy_client_spec.rb
@@ -18,6 +18,7 @@ require 'spec_helper'
 describe ClassyClient do
 
   before do
+    # TODO: kill timecop with fire and paradoxes
     Timecop.freeze(THE_TIME)
     ENV['CLASSY_CLIENT_ID'] = 'some_id'
     ENV['CLASSY_CLIENT_SECRET'] = 'some_secret'

--- a/spec/models/payment_requirement_spec.rb
+++ b/spec/models/payment_requirement_spec.rb
@@ -22,9 +22,6 @@ describe PaymentRequirement do
   let (:tier2) { FactoryBot.create :tier2 }
   let (:tier3) { FactoryBot.create :tier3 }
 
-  before { Timecop.freeze(THE_TIME) }
-  after  { Timecop.return }
-
   describe '#stripe_params' do
     let(:req)  { FactoryBot.create :payment_requirement_with_tier }
     let(:team) { FactoryBot.create :team, race: req.race }

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -92,12 +92,10 @@ describe Team do
       let(:team) { FactoryBot.create :team, :with_enough_people }
 
       it 'sets finalized boolean and notified_at in the db' do
-        Timecop.freeze(THE_TIME) do
-          team.finalize
-          record = Team.find(team.id)
-          expect(record.notified_at.to_datetime).to eq(THE_TIME.to_datetime)
-          expect(record.finalized).to be_truthy
-        end
+        team.finalize
+        record = Team.find(team.id)
+        expect(record.notified_at).to_not be_nil
+        expect(record.finalized).to be true
       end
 
       context 'team number assignments' do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -19,24 +19,32 @@ describe Team do
 
   describe 'scopes' do
     describe 'all_finalized' do
-      before do
-        @finalized = FactoryBot.create :finalized_team
-        FactoryBot.create :team
-      end
+      let!(:team) { FactoryBot.create :finalized_team }
 
       it 'returns only finalized teams' do
-        expect(Team.all_finalized).to eq([@finalized])
+        FactoryBot.create :team
+        expect(Team.all_finalized).to eq([team])
       end
     end
 
     describe 'all_unfinalized' do
-      before do
-        FactoryBot.create :finalized_team
-        @unfinalized = FactoryBot.create :team
+      let!(:team) { FactoryBot.create :finalized_team }
+
+      it 'returns only unfinalized teams' do
+        unfinalized = FactoryBot.create :team
+        expect(Team.all_unfinalized).to eq([unfinalized])
+      end
+    end
+
+    describe 'belonging_to' do
+      let!(:team) { FactoryBot.create :team }
+
+      it 'returns teams created by a specific user' do
+        expect(Team.belonging_to(team.user_id)).to eq([team])
       end
 
-      it 'returns only finalized teams' do
-        expect(Team.all_unfinalized).to eq([@unfinalized])
+      it 'returns empty if not a match' do
+        expect(Team.belonging_to(team.user_id + 1)).to be_empty
       end
     end
   end

--- a/spec/models/tier_spec.rb
+++ b/spec/models/tier_spec.rb
@@ -17,13 +17,8 @@ require 'spec_helper'
 
 describe Tier do
 
-  before { Timecop.freeze(THE_TIME) }
-  after  { Timecop.return }
-
   let!(:req) do
-    Timecop.freeze(THE_TIME) do
-      FactoryBot.create :payment_requirement_with_tier
-    end
+    FactoryBot.create :payment_requirement_with_tier
   end
 
   let(:tier) { req.reload.tiers.first }
@@ -46,7 +41,7 @@ describe Tier do
     end
 
     it 'fails when another tier has the same "begin_at" value' do
-      tier2 = FactoryBot.build :tier, :price => 6000
+      tier2 = FactoryBot.build :tier, price: 6000, begin_at: tier.begin_at
       req.tiers << tier2
       expect(tier2).to be_invalid
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,7 +80,7 @@ include Authlogic::TestCase
 require "cancan/matchers"
 
 # Global time constant for use with Timecop
-THE_TIME = Time.local(1980, 9, 1, 12, 0, 0)
+THE_TIME = Time.zone.local(1980, 9, 1, 12, 0, 0)
 
 def mock_login!(user)
   expect(user).to_not be_nil

--- a/spec/workers/classy_create_fundraising_page_spec.rb
+++ b/spec/workers/classy_create_fundraising_page_spec.rb
@@ -82,7 +82,7 @@ describe Workers::ClassyCreateFundraisingPage do
     end
 
     context 'when classy client errors' do
-      let(:race) { FactoryBot.create :race_with_classy_data }
+      let(:race) { FactoryBot.create :race, :with_classy_data }
       let(:user) { FactoryBot.create :user, :with_classy_id }
       let(:team) { FactoryBot.create :team, :with_classy_id, race: race, user: user }
       let(:ex)   { StandardError.new("omg") }
@@ -102,7 +102,7 @@ describe Workers::ClassyCreateFundraisingPage do
 
 
     context 'when the fundraising page creation is successful' do
-      let(:race) { FactoryBot.create :race_with_classy_data }
+      let(:race) { FactoryBot.create :race, :with_classy_data }
       let(:user) { FactoryBot.create :user, :with_classy_id }
       let(:team) { FactoryBot.create :team, :with_classy_id, race: race, user: user }
       let(:resp) { File.read("#{Rails.root}/spec/fixtures/classy/create_fundraising_page_response.json") }

--- a/spec/workers/classy_create_fundraising_team_spec.rb
+++ b/spec/workers/classy_create_fundraising_team_spec.rb
@@ -85,7 +85,7 @@ describe Workers::ClassyCreateFundraisingTeam do
     end
 
     context 'when user who owns the team cannot be linked to classy' do
-      let(:race) { FactoryBot.create :race_with_classy_data }
+      let(:race) { FactoryBot.create :race, :with_classy_data }
       let(:team) { FactoryBot.create :team, race: race }
       let(:ex)   { StandardError.new("omg") }
 
@@ -99,7 +99,7 @@ describe Workers::ClassyCreateFundraisingTeam do
     end
 
     context 'when classy client errors' do
-      let(:race) { FactoryBot.create :race_with_classy_data }
+      let(:race) { FactoryBot.create :race, :with_classy_data }
       let(:team) { FactoryBot.create :team, race: race }
       let(:ex)   { StandardError.new("omg") }
       before do
@@ -118,7 +118,7 @@ describe Workers::ClassyCreateFundraisingTeam do
 
 
     context 'when the fundraising team creation is successful' do
-      let(:race) { FactoryBot.create :race_with_classy_data }
+      let(:race) { FactoryBot.create :race, :with_classy_data }
       let(:team) { FactoryBot.create :team, race: race }
       let(:resp) { File.read("#{Rails.root}/spec/fixtures/classy/create_campaign_team_response.json") }
       let(:json) { JSON.parse(resp) }


### PR DESCRIPTION
- Enables editing the team's racer data if now is in-between reg close and final edits close
- Uncomplicates the cancancan abilities model
- Mostly kills Timecop.  There's still one pesky instance
- Adds test coverage
- UI improvements; new theme style