### PR TITLE
Prevent caching of team#show and team#edit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,6 +41,12 @@ class ApplicationController < ActionController::Base
     true
   end
 
+  def set_no_cache
+    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
+  end
+
   private
 
   def is_production?

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,6 +15,8 @@
 # along with dogtag.  If not, see <http://www.gnu.org/licenses/>.
 class TeamsController < ApplicationController
   before_filter :require_user
+  before_filter :set_no_cache, only: %w{show edit}
+
   load_and_authorize_resource
 
   def index

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -365,6 +365,12 @@ describe TeamsController do
           expect(response).to be_success
         end
 
+        it 'does not cache this page' do
+          get :show, :id => team.id
+          expect(response.headers['Cache-Control']).to eq('no-cache, no-store, max-age=0, must-revalidate')
+          expect(response.headers['Pragma']).to eq('no-cache')
+        end
+
         context "if the team is finalized" do
           let(:team) { FactoryBot.create :finalized_team }
 


### PR DESCRIPTION
To ensure payment details update immediately.