### PR TITLE
Remove reference to objects removed after rails 5.1.7

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,6 @@ class ApplicationController < ActionController::Base
   unless Rails.configuration.consider_all_requests_local
     rescue_from Exception, :with => :render_error
     rescue_from ActionController::RoutingError, :with => :render_not_found
-    rescue_from ActionController::UnknownController, :with => :render_not_found
     rescue_from CanCan::AccessDenied, :with => :render_access_denied
   end
   # we always want these (including during tests)


### PR DESCRIPTION
As observed in heroku:
```
2022-11-29T22:52:11.029402+00:00 app[web.1]: bundler: failed to load command: unicorn (/app/vendor/bundle/ruby/2.7.0/bin/unicorn)
2022-11-29T22:52:11.029656+00:00 app[web.1]: /app/app/controllers/application_controller.rb:31:in `<class:ApplicationController>': uninitialized constant ActionController::UnknownController (NameError)
2022-11-29T22:52:11.029681+00:00 app[web.1]: from /app/app/controllers/application_controller.rb:18:in `<main>'
2022-11-29T22:52:11.029690+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.14.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
2022-11-29T22:52:11.029692+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.14.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
2022-11-29T22:52:11.029700+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies/interlock.rb:14:in `block in loading'
2022-11-29T22:52:11.029708+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/concurrency/share_lock.rb:151:in `exclusive'
2022-11-29T22:52:11.029715+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.8.1/lib/active_support/dependencies/interlock.rb:13:in `loading'
2022-11-29T22:52:11.029734+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:478:in `block (2 levels) in eager_load!'
2022-11-29T22:52:11.029734+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:477:in `each'
2022-11-29T22:52:11.029735+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:477:in `block in eager_load!'
2022-11-29T22:52:11.029742+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:475:in `each'
2022-11-29T22:52:11.029755+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:475:in `eager_load!'
2022-11-29T22:52:11.029757+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/engine.rb:356:in `eager_load!'
2022-11-29T22:52:11.029758+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/application/finisher.rb:69:in `each'
2022-11-29T22:52:11.029765+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/application/finisher.rb:69:in `block in <module:Finisher>'
2022-11-29T22:52:11.029772+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:32:in `instance_exec'
2022-11-29T22:52:11.029779+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:32:in `run'
2022-11-29T22:52:11.029786+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:61:in `block in run_initializers'
2022-11-29T22:52:11.029814+00:00 app[web.1]: from /app/vendor/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
2022-11-29T22:52:11.029817+00:00 app[web.1]: from /app/vendor/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
2022-11-29T22:52:11.029817+00:00 app[web.1]: from /app/vendor/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
2022-11-29T22:52:11.029817+00:00 app[web.1]: from /app/vendor/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
2022-11-29T22:52:11.029818+00:00 app[web.1]: from /app/vendor/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:347:in `each'
2022-11-29T22:52:11.029818+00:00 app[web.1]: from /app/vendor/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:347:in `call'
2022-11-29T22:52:11.029818+00:00 app[web.1]: from /app/vendor/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
2022-11-29T22:52:11.029820+00:00 app[web.1]: from /app/vendor/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
2022-11-29T22:52:11.029822+00:00 app[web.1]: from /app/vendor/ruby-2.7.6/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
2022-11-29T22:52:11.029830+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/initializable.rb:60:in `run_initializers'
2022-11-29T22:52:11.029832+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/railties-5.2.8.1/lib/rails/application.rb:361:in `initialize!'
2022-11-29T22:52:11.029840+00:00 app[web.1]: from /app/config/environment.rb:5:in `<top (required)>'
2022-11-29T22:52:11.029848+00:00 app[web.1]: from config.ru:4:in `require'
2022-11-29T22:52:11.029850+00:00 app[web.1]: from config.ru:4:in `block in <main>'
2022-11-29T22:52:11.029858+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/rack-2.2.4/lib/rack/builder.rb:125:in `instance_eval'
2022-11-29T22:52:11.029865+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/rack-2.2.4/lib/rack/builder.rb:125:in `initialize'
2022-11-29T22:52:11.029873+00:00 app[web.1]: from config.ru:1:in `new'
2022-11-29T22:52:11.029880+00:00 app[web.1]: from config.ru:1:in `<main>'
2022-11-29T22:52:11.029887+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/unicorn-6.1.0/lib/unicorn.rb:54:in `eval'
2022-11-29T22:52:11.029907+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/unicorn-6.1.0/lib/unicorn.rb:54:in `block in builder'
2022-11-29T22:52:11.029907+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:821:in `build_app!'
2022-11-29T22:52:11.029907+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:140:in `start'
2022-11-29T22:52:11.029907+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/unicorn-6.1.0/bin/unicorn:128:in `<top (required)>'
2022-11-29T22:52:11.029910+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/bin/unicorn:23:in `load'
2022-11-29T22:52:11.029917+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/bin/unicorn:23:in `<top (required)>'
2022-11-29T22:52:11.029924+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/lib/bundler/cli/exec.rb:58:in `load'
2022-11-29T22:52:11.029932+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/lib/bundler/cli/exec.rb:58:in `kernel_load'
2022-11-29T22:52:11.029939+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/lib/bundler/cli/exec.rb:23:in `run'
2022-11-29T22:52:11.029946+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/lib/bundler/cli.rb:486:in `exec'
2022-11-29T22:52:11.029953+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
2022-11-29T22:52:11.029961+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
2022-11-29T22:52:11.029968+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
2022-11-29T22:52:11.029978+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/lib/bundler/cli.rb:31:in `dispatch'
2022-11-29T22:52:11.029978+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
2022-11-29T22:52:11.029980+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/lib/bundler/cli.rb:25:in `start'
2022-11-29T22:52:11.029988+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/exe/bundle:48:in `block in <top (required)>'
2022-11-29T22:52:11.029990+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
2022-11-29T22:52:11.029998+00:00 app[web.1]: from /app/vendor/bundle/ruby/2.7.0/gems/bundler-2.3.25/exe/bundle:36:in `<top (required)>'
2022-11-29T22:52:11.030005+00:00 app[web.1]: from /app/bin/bundle:3:in `load'
2022-11-29T22:52:11.030012+00:00 app[web.1]: from /app/bin/bundle:3:in `<main>'
```