### PR TITLE
Ensure classy api is always called when link_user_to_classy! is called

### DIFF
--- a/lib/classy_user.rb
+++ b/lib/classy_user.rb
@@ -18,9 +18,6 @@ class ClassyUser
   # associate dogtag user account with an existing classy user, or tell classy
   # to make a new association and send them an invite to the classy platform.
   def self.link_user_to_classy!(user, race)
-
-    return user if user.classy_id.present?
-
     cc = ClassyClient.new
 
     if result = cc.get_member(user.email)

--- a/spec/lib/classy_user_spec.rb
+++ b/spec/lib/classy_user_spec.rb
@@ -24,14 +24,23 @@ describe ClassyUser do
 
     context "when user already has a classy id in db" do
       let(:user) { FactoryBot.create :user, :with_classy_id }
+      let(:cc)   { double(ClassyClient) }
 
-      it "returns the user object" do
-        expect(result).to eq(user)
+      before do
+        expect(ClassyClient).to receive(:new).and_return(cc)
+      end
+
+      context "and the classy id associated with the user's email address has changed" do
+        it "saves the new classy id in the user object" do
+          expect(user.classy_id).to eq(123456)
+          expect(cc).to receive(:get_member).and_return({'id' => '123'})
+          expect(result.classy_id).to eq(123)
+          expect(user.reload.classy_id).to eq(123)
+        end
       end
     end
 
     context "when user has no classy id" do
-
       let(:user) { FactoryBot.create :user }
       let(:cc)   { double(ClassyClient) }
 
@@ -40,7 +49,6 @@ describe ClassyUser do
       end
 
       context "user email address has classy account" do
-
         it "associates the user with classy and returns the user object" do
           expect(user.classy_id).to be_nil
           expect(cc).to receive(:get_member).and_return({'id' => '123'})
@@ -49,7 +57,6 @@ describe ClassyUser do
       end
 
       context "when email address is not found in classy" do
-
         it "creates a new classy member, associates the user with classy and returns the user object" do
           expect(user.classy_id).to be_nil
           expect(cc).to receive(:get_member).and_return(nil)


### PR DESCRIPTION
This PR addresses https://github.com/chiditarod/dogtag/issues/162

This ensures the email address of the dogtag user is what is used to to request an existing classy id, or to create a classy account.

This change fixes the bug if a dogtag user account was used in an earlier race, and there is an existing classy id stored on that user account, and then the dogtag team changes their email address, and then registers for a new race.  in this scenario, the code sees the existing classy id and just returns it instead of requesting a classy id (or initiating the new classy account creation) using that newer email address.  The result of this bug is that the old classy account gets associated with the new race.  This is fine if the classy account is still using the same email address, but causes problems if the dogtag email address ever changes, or if the email address associated with the old classy account becomes inaccessible.

This also works in the scenario where a dogtag user changes their email address, and also changes it in classy.  In that case, the link will remain correct since the classy api lookup is by email address.