### PR TITLE
Fix select2 functonality for refunder role

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with dogtag.  If not, see <http://www.gnu.org/licenses/>.
 class UsersController < ApplicationController
-  before_action :require_user, :except => [:new, :create]
+  before_action :require_user, except: [:new, :create]
   before_action :set_no_cache, only: %w{search}
   load_and_authorize_resource
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -60,14 +60,15 @@ class Ability
     # no user-level access required
 
     if user.is? :refunder
-      can [:index], User
-      can [:index, :show], Team
+      can [:index, :search, :show], User
+      can [:index, :search, :show], Team
       can [:refund], :charges
     end
 
     if user.is? :operator
       can [:export], Race
-      can [:index, :show, :edit, :update], [Team, Person]
+      can [:index, :search, :show], User
+      can [:index, :search, :show, :edit, :update], [Team, Person]
       can [:index, :show, :edit, :update, :create], [Race, PaymentRequirement, Tier]
       can [:refund], :charges
     end

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -24,7 +24,7 @@
               %i.fa.fa-users.fa-2x
               =t '.my_teams'
 
-        - if current_user.gets_admin_menu?
+        - if current_user.gets_admin_menu? || current_user.is?(:refunder)
           %li.dropdown
             %a.dropdown-toggle{"data-toggle" => "dropdown", href: "#"}
               %i.fa.fa-star-o.fa-2x

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,11 +1,12 @@
 %h1
   = t('.search')
-  
-= form_with id: "search-form", url: "#", method: :get, local: true do |f|
-  = f.select :user_id, [], {}, class: 'select2-name', data: { placeholder: 'Search by first, last, or email', url: search_users_path }
-  = f.hidden_field :id, id: 'selected-user-id'
-  = f.select :team_id, [], {}, class: 'select2-team', data: { placeholder: 'Search by team name', url: search_teams_path }
-  = f.hidden_field :team_id, id: 'selected-team-id' 
+
+- if current_user.gets_admin_menu? || current_user.is?(:refunder)
+  = form_with id: "search-form", url: "#", method: :get, local: true do |f|
+    = f.select :user_id, [], {}, class: 'select2-name', data: { placeholder: 'Search by first, last, or email', url: search_users_path }
+    = f.hidden_field :id, id: 'selected-user-id'
+    = f.select :team_id, [], {}, class: 'select2-team', data: { placeholder: 'Search by team name', url: search_teams_path }
+    = f.hidden_field :team_id, id: 'selected-team-id' 
 
 %hr
 


### PR DESCRIPTION
Ensure the refunder role can view the navbar, request the api endpoints that populate select2, and visit the team and user #show.  the issue above was testing was done using an admin account without confirming the refunder role has he required access to the backend.